### PR TITLE
Added multiprocessing capability for ObfuscateLogs

### DIFF
--- a/python/obfuscateLogs/README.md
+++ b/python/obfuscateLogs/README.md
@@ -4,6 +4,8 @@ Warning: this code is provided on a best effort basis and is not in any way offi
 
 This script will obfuscate the file paths (and other path-like strings) in log files. The script will unzip/re-zip and untar/tar gz and tar files.
 
+Note: Minimum python version required - v3.2
+
 ## Download the script
 
 You can download the scripts using the following commands:
@@ -21,12 +23,19 @@ chmod +x obfuscateLogs.py
 * [obfuscateLogs.py](https://raw.githubusercontent.com/cohesity/community-automation-samples/main/python/obfuscateLogs/obfuscateLogs.py): the main python script
 * [pyhesity.py](https://raw.githubusercontent.com/cohesity/community-automation-samples/main/python/pyhesity.py): the Cohesity REST API helper module
 
-Place your log files in a folder (the script will process all files in that folder), then run the main script like so:
+Place your log files in a folder (the script will process all files in that folder), then run the main script like so if you want to run it sequentially:
 
 ```bash
 ./obfuscateLogs.py -l ~/mylogs/
 ```
 
+To run parallelly:
+```bash
+./obfuscateLogs.py -l ~/mylogs/ -p
+```
+
 ## Parameters
 
-* -l, --logpath: path of folder containing logs
+* -l, --logpath: path of folder containing logs (Required)
+* -p, --parallel: Launch parallel tasks for concurrent file processing (Optional)
+* -w, --workers: No. of concurrent processes to run if parallel processinf is selected. If it is not provided with '-p' argument then it will default to the number of processors on the machine.  (Optional)

--- a/python/obfuscateLogs/obfuscateLogs.py
+++ b/python/obfuscateLogs/obfuscateLogs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""obfuscate logs - version 2024-05-28a"""
+"""obfuscate logs - version 2024-06-12a"""
 
 import os
 import gzip
@@ -7,18 +7,11 @@ import shutil
 import re
 import codecs
 import tarfile
+from concurrent.futures import ProcessPoolExecutor
+import time
 
 # command line arguments
 import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument('-l', '--logpath', type=str, required=True)
-args = parser.parse_args()
-
-logpath = args.logpath
-
-if os.path.isdir(logpath) is False:
-    print('logpath %s is not found' % logpath)
-    exit(1)
 
 ignore_paths = [
     '/td',
@@ -134,53 +127,86 @@ def obfuscatefile(root, filepath):
             os.remove(filepath)
             os.rename(outfile, filepath)
 
-
 def gzfile(path):
     with open(path, 'rb') as f_in:
         with gzip.open('%s.gz' % path, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
 
 
-def targzdirectory(path,name):
+def targzdirectory(path, name):
     with tarfile.open(name, "w:gz") as tarhandle:
         for root, dirs, files in os.walk(path):
             for f in files:
                 fullname = os.path.join(root, f)
-                relname = fullname.replace(path,'')
+                relname = fullname.replace(path, '')
                 tarhandle.add(os.path.join(root, f), arcname=relname)
 
+def process_file(root, filename, parallel=True):
+    filepath = os.path.join(root, filename)
+    filename_short, file_extension = os.path.splitext(filename)
+    if file_extension.lower() == '.gz':
+        # unzip gz file
+        unzippedfile = os.path.join(root, filename_short)
+        with gzip.open(filepath, 'rb') as f_in:
+            with open(unzippedfile, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        os.remove(filepath)
+        unzipped_filename_short, unzipped_file_extension = os.path.splitext(unzippedfile)
+        if unzipped_file_extension.lower() == '.tar':
+            # untar tar file
+            untarred_folder = unzippedfile[0:-4]
+            tar = tarfile.open(unzippedfile, 'r')
+            tar.extractall(untarred_folder)
+            tar.close()
+            os.remove(unzippedfile)
+            walkdir(untarred_folder, parallel=parallel, max_workers=None)
+            # re-tar and re-zip
+            targzdirectory(untarred_folder, filepath)
+            shutil.rmtree(untarred_folder)
+        else:
+            obfuscatefile(root, unzippedfile)
+            # re-zip
+            gzfile(unzippedfile)
+            os.remove(unzippedfile)
+    else:
+        obfuscatefile(root, filepath)
 
-def walkdir(thispath):
-    for root, dirs, files in os.walk(thispath):
-        for filename in sorted(files):
-            filepath = os.path.join(root, filename)
-            filename_short, file_extension = os.path.splitext(filename)
-            if file_extension.lower() == '.gz':
-                # unzip gz file
-                unzippedfile = os.path.join(root, filename_short)
-                with gzip.open(filepath, 'rb') as f_in:
-                    with open(unzippedfile, 'wb') as f_out:
-                        shutil.copyfileobj(f_in, f_out)
-                os.remove(filepath)
-                unzipped_filename_short, unzipped_file_extension = os.path.splitext(unzippedfile)
-                if unzipped_file_extension.lower() == '.tar':
-                    # untar tar file
-                    untarred_folder = unzippedfile[0:-4]
-                    tar = tarfile.open(unzippedfile, 'r')
-                    tar.extractall(untarred_folder)
-                    tar.close()
-                    os.remove(unzippedfile)
-                    walkdir(untarred_folder)
-                    # re-tar and re-zip
-                    targzdirectory(untarred_folder, filepath)
-                    shutil.rmtree(untarred_folder)
-                else:
-                    obfuscatefile(root, unzippedfile)
-                    # re-zip
-                    gzfile(unzippedfile)
-                    os.remove(unzippedfile)
-            else:
-                obfuscatefile(root, filepath)
+def walkdir(thispath, parallel=False, max_workers=None):
+    tasks = []
+    if parallel:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            for root, dirs, files in os.walk(thispath):
+                for filename in sorted(files):
+                    future = executor.submit(process_file, root, filename)
+                    future.add_done_callback(task_done)
+                    tasks.append(future)
+    else:
+        for root, dirs, files in os.walk(thispath):
+            for filename in sorted(files):
+                process_file(root, filename, parallel=False)
 
+def task_done(future):
+    try:
+        result = future.result()
+    except Exception as e:
+        print(f"Task generated an exception: {e}")
 
-walkdir(logpath)
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-l', '--logpath', type=str, required=True)
+    parser.add_argument('-w', '--workers', type=int, default=None, help='Number of worker processes')
+    parser.add_argument('-p', '--parallel', action='store_true', help='Run in parallel using ProcessPoolExecutor')
+    args = parser.parse_args()
+    
+    logpath = args.logpath
+
+    if os.path.isdir(logpath) is False:
+        print('logpath %s is not found' % logpath)
+        exit(1)
+    start_time = time.time()
+    walkdir(logpath, parallel=args.parallel, max_workers=args.workers)
+    end_time = time.time()
+    
+    # Calculate and print the execution time
+    execution_time = end_time - start_time
+    print(f"Execution time: {execution_time} seconds")


### PR DESCRIPTION
- Used [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html) to launch parallel processes to obfuscate log files concurrently.
- Retained the original sequential processing capability as well. 
- Updated the README with additional arguments.
- Minimum Python version required: v3.2.