### PR TITLE
fix bug: do not select the lastest snapshot/pit with --latest flag

### DIFF
--- a/oracle/python/mountOracleAsView/mountOracleAsView.py
+++ b/oracle/python/mountOracleAsView/mountOracleAsView.py
@@ -102,6 +102,7 @@ for object in objects:
     for jobInfo in availableJobInfos:
         snapshots = api('get', 'data-protect/objects/%s/snapshots?protectionGroupIds=%s' % (object['id'], jobInfo['protectionGroupId']), v=2)
         snapshots = [s for s in snapshots['snapshots'] if s['snapshotTimestampUsecs'] <= desiredPIT]
+        snapshots = sorted(snapshots, key=lambda o: o['snapshotTimestampUsecs'], reverse=True)
         if snapshots is not None and len(snapshots) > 0:
             if snapshots[0]['snapshotTimestampUsecs'] > latestSnapshotTimeStamp:
                 latestSnapshot = snapshots[0]
@@ -142,6 +143,7 @@ if logtime is not None or latest:
             logRanges = [logRanges]
         for logRange in logRanges:
             if 'timeRanges' in logRange:
+                logRange['timeRanges'] = sorted(logRange['timeRanges'], key=lambda o: o['endTimeUsecs'], reverse=True)
                 if logRange['timeRanges'][0]['endTimeUsecs'] > latestLogPIT:
                     latestLogPIT = logRange['timeRanges'][0]['endTimeUsecs']
                 if latest:


### PR DESCRIPTION
I think an easy fix is to sort the snapshots before selecting the first one. I'm running cohesity 6.8.2 and snapshot list start with the oldest one (smallest snapshotTimestampUsecs).

```
if snapshots is not None and len(snapshots) > 0:
            if snapshots[0]['snapshotTimestampUsecs'] > latestSnapshotTimeStamp:
                latestSnapshot = snapshots[0]          <-- WE JUST SELECT THE FIRST ONE, WHY ? DO WE PRESUME ALREADY SORTED ?
                latestSnapshotTimeStamp = snapshots[0]['snapshotTimestampUsecs']
                latestSnapshotObject = object
```

same thing for pointsForTimeRange

```
if logRange['timeRanges'][0]['endTimeUsecs'] > latestLogPIT:
                    latestLogPIT = logRange['timeRanges'][0]['endTimeUsecs']
                if latest:
                    pit = logRange['timeRanges'][0]['endTimeUsecs']  <-- WE JUST SELECT THE FIRST ONE, WHY ? DO WE PRESUME ALREADY SORTED ?
                    break
                else:
                    if logRange['timeRanges'][0]['endTimeUsecs'] > desiredPIT and logRange.timeRanges[0]['startTimeUsecs'] <= desiredPIT:
                        pit = desiredPIT
                        break
```